### PR TITLE
Update Filter.Archived to be a tristate

### DIFF
--- a/asana/asana.go
+++ b/asana/asana.go
@@ -137,7 +137,7 @@ type (
 	}
 
 	Filter struct {
-		Archived       bool     `url:"archived,omitempty"`
+		Archived       *bool    `url:"archived,omitempty"`
 		Assignee       int64    `url:"assignee,omitempty"`
 		AssigneeGID    int64    `url:"assignee,omitempty"`
 		Project        int64    `url:"project,omitempty"`
@@ -502,4 +502,9 @@ func toURLValues(m map[string]string) url.Values {
 		values[k] = []string{v}
 	}
 	return values
+}
+
+// Bool returns a pointer to a bool.
+func Bool(b bool) *bool {
+	return &b
 }


### PR DESCRIPTION
Hello @chrisforrette,

The asana API behaves differently based on whether false, undefined, or true are
passed. This change allows the Filter struct to express those three states.

Please review the following commits I made in branch dpup/filter:

8ec2e093003a057adbf69028e635549cd451002c (2020-01-10 16:28:20 -0800)
Update Filter.Archived to be a tristate

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics