### PR TITLE
Add response to error

### DIFF
--- a/asana/asana.go
+++ b/asana/asana.go
@@ -174,13 +174,13 @@ type (
 	Errors []Error
 
 	// HTTP request error
-	requestError struct {
+	RequestError struct {
 		Body string
 		Code int
 	}
 )
 
-func (re requestError) Error() string {
+func (re RequestError) Error() string {
 	txt := "request error"
 	switch re.Code {
 	case http.StatusBadRequest:
@@ -198,7 +198,7 @@ func (re requestError) Error() string {
 	case http.StatusInternalServerError:
 		txt = "internal server error"
 	}
-	return fmt.Sprintf("asana: Error: %s, got HTTP response code %d with body: %v", txt, re.Code, re.Body)
+	return fmt.Sprintf("asana: Error: %s, got HTTP response code %d", txt, re.Code)
 }
 
 func (f DoerFunc) Do(req *http.Request) (resp *http.Response, err error) {
@@ -473,7 +473,7 @@ func (c *Client) request(ctx context.Context, method string, path string, data i
 		if rerr != nil {
 			return nil, fmt.Errorf("asana: Error reading response body: %s", rerr)
 		}
-		return nil, &requestError{
+		return nil, &RequestError{
 			Body: string(body),
 			Code: resp.StatusCode,
 		}

--- a/asana/asana.go
+++ b/asana/asana.go
@@ -471,7 +471,7 @@ func (c *Client) request(ctx context.Context, method string, path string, data i
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, rerr := ioutil.ReadAll(resp.Body)
 		if rerr != nil {
-			return nil, rerr
+			return nil, fmt.Errorf("asana: Error reading response body: %s", rerr)
 		}
 		return nil, &requestError{
 			Body: string(body),

--- a/asana/asana_test.go
+++ b/asana/asana_test.go
@@ -225,8 +225,15 @@ func TestUnauthorized(t *testing.T) {
 	})
 
 	_, err := client.ListTags(context.Background(), nil)
-	if err == nil || err.Code != http.StatusUnauthorized {
-		t.Errorf("Unexpected err %v", err)
+	if err == nil {
+		t.Error("No error when one was expected")
+	}
+	rerr, ok := err.(*RequestError)
+	if !ok {
+		t.Error("Unable to cast error as RequestError")
+	}
+	if rerr.Code != http.StatusUnauthorized {
+		t.Errorf("Unexpected response status code: %d", rerr.Code)
 	}
 }
 

--- a/asana/asana_test.go
+++ b/asana/asana_test.go
@@ -225,7 +225,7 @@ func TestUnauthorized(t *testing.T) {
 	})
 
 	_, err := client.ListTags(context.Background(), nil)
-	if err != ErrUnauthorized {
+	if err == nil || err.Code != http.StatusUnauthorized {
 		t.Errorf("Unexpected err %v", err)
 	}
 }


### PR DESCRIPTION
We currently lose a lot of context around Asana errors because what is returned is just a constant. I wanted to take a stab at getting the response and the error object into what's returned so that they can get included in our logs downstream. I'm guessing what I've done here is not the best approach but it's at least a starting point to discuss.